### PR TITLE
set X-Accel-Buffering=no response header for nginx

### DIFF
--- a/sse_wrapper/views.py
+++ b/sse_wrapper/views.py
@@ -43,6 +43,7 @@ class EventStreamView(View):
         response = HttpResponse(self._generate_content(),
                                 content_type="text/event-stream")
         response['Cache-Control'] = 'no-cache'
+        response['X-Accel-Buffering'] = 'no'
         response['Software'] = 'django-sse-wrapper'
         return response
 


### PR DESCRIPTION
add X-Accel-Buffering=no response header for nginx, so that not need set `uwsgi_buffering off;` in nginx config.

http://stackoverflow.com/questions/13672743/eventsource-server-sent-events-through-nginx#comment25280208_13673298

http://wiki.nginx.org/X-accel#X-Accel-Buffering
